### PR TITLE
Caps Update 20231103

### DIFF
--- a/diffs/pre_mainnetCapsIncrease_20231103_post_mainnetCapsIncrease_20231103.md
+++ b/diffs/pre_mainnetCapsIncrease_20231103_post_mainnetCapsIncrease_20231103.md
@@ -1,0 +1,25 @@
+## Reserve changes
+
+### Reserves altered
+
+#### rETH ([0xae78736Cd615f374D3085123A210448E74Fc6393](https://etherscan.io/address/0xae78736Cd615f374D3085123A210448E74Fc6393))
+
+| description | value before | value after |
+| --- | --- | --- |
+| borrowCap | 9,600 rETH | 19,200 rETH |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0xae78736Cd615f374D3085123A210448E74Fc6393": {
+      "borrowCap": {
+        "from": 9600,
+        "to": 19200
+      }
+    }
+  }
+}
+```

--- a/src/MainnetCapsIncrease_20231103.s.sol
+++ b/src/MainnetCapsIncrease_20231103.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {CapsPlusRiskStewardMainnet} from '../scripts/CapsPlusRiskStewardMainnet.s.sol';
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+
+/**
+ * @title Increase Caps on Ethereum V3
+ * @author @ChaosLabsInc
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-caps-on-v3-ethereum-and-arbitrum-11-02-2023/15312
+ */
+contract MainnetCapsIncrease_20231103 is CapsPlusRiskStewardMainnet {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'mainnetCapsIncrease_20231103';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3EthereumAssets.rETH_UNDERLYING,
+      EngineFlags.KEEP_CURRENT,
+      19_200
+    );
+
+    return capUpdates;
+  }
+}


### PR DESCRIPTION
Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-caps-on-v3-ethereum-and-arbitrum-11-02-2023/15312