### PR TITLE
Increase Caps and Execute AIP-414

### DIFF
--- a/diffs/pre_PolygonUSDCeCapIncrease_20231221_post_PolygonUSDCeCapIncrease_20231221.md
+++ b/diffs/pre_PolygonUSDCeCapIncrease_20231221_post_PolygonUSDCeCapIncrease_20231221.md
@@ -1,0 +1,30 @@
+## Reserve changes
+
+### Reserves altered
+
+#### USDC ([0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174](https://polygonscan.com/address/0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174))
+
+| description | value before | value after |
+| --- | --- | --- |
+| supplyCap | 40,000,000 USDC | 48,000,000 USDC |
+| borrowCap | 36,000,000 USDC | 43,500,000 USDC |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174": {
+      "borrowCap": {
+        "from": 36000000,
+        "to": 43500000
+      },
+      "supplyCap": {
+        "from": 40000000,
+        "to": 48000000
+      }
+    }
+  }
+}
+```

--- a/src/PolygonExecutePayload_20231221.s.sol
+++ b/src/PolygonExecutePayload_20231221.s.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import "forge-std/Test.sol";
+import {GovernanceV3Polygon} from "aave-address-book/GovernanceV3Polygon.sol";
+import {IPayloadsControllerCore} from "aave-address-book/GovernanceV3.sol";
+import {PolygonUSDCeCapIncrease_20231221} from "src/PolygonUSDCeCapIncrease_20231221.s.sol";
+
+contract ExecutePayloadScript is Script, Test {
+    error FailedUpdate();
+    error payloadStateNotExecuted();
+    error payloadStateNotQueued();
+
+    address constant SAFE_ADDRESS = 0x2C40FB1ACe63084fc0bB95F83C31B5854C6C4cB5;
+    uint40 constant PAYLOAD_ID = 22;
+
+    function setUp() public {
+        vm.createSelectFork(vm.rpcUrl("polygon"), 51395133);
+    }
+
+    function run() external {
+        PolygonUSDCeCapIncrease_20231221 capIncrease = new PolygonUSDCeCapIncrease_20231221();
+        capIncrease.run(false);
+
+        IPayloadsControllerCore.PayloadState payloadState =
+            GovernanceV3Polygon.PAYLOADS_CONTROLLER.getPayloadState(PAYLOAD_ID);
+        if (uint256(payloadState) != 2) {
+            revert payloadStateNotQueued();
+        }
+
+        bool success;
+        bytes memory resultData;
+        vm.startPrank(SAFE_ADDRESS);
+        bytes memory callData =
+            abi.encodeWithSelector(GovernanceV3Polygon.PAYLOADS_CONTROLLER.executePayload.selector, PAYLOAD_ID);
+        (success, resultData) = address(GovernanceV3Polygon.PAYLOADS_CONTROLLER).call(callData);
+        _verifyCallResult(success, resultData);
+        vm.stopPrank();
+
+        payloadState = GovernanceV3Polygon.PAYLOADS_CONTROLLER.getPayloadState(PAYLOAD_ID);
+
+        if (uint256(payloadState) != 3) {
+            revert payloadStateNotExecuted();
+        }
+
+        emit log_string("Payload 22 Execution Calldata:");
+        emit log_bytes(callData);
+    }
+
+    function _verifyCallResult(bool success, bytes memory returnData) private pure returns (bytes memory) {
+        if (success) {
+            return returnData;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returnData.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    let returndata_size := mload(returnData)
+                    revert(add(32, returnData), returndata_size)
+                }
+            } else {
+                revert FailedUpdate();
+            }
+        }
+    }
+}

--- a/src/PolygonUSDCeCapIncrease_20231221.s.sol
+++ b/src/PolygonUSDCeCapIncrease_20231221.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {CapsPlusRiskStewardPolygon} from '../scripts/CapsPlusRiskStewardPolygon.s.sol';
+
+/**
+ * @title Increase USDC.e Cap on Polygon V3, and execute AIP-414
+ * @author @ChaosLabsInc
+ * - Discussion:
+ */
+contract PolygonUSDCeCapIncrease_20231221 is CapsPlusRiskStewardPolygon {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'PolygonUSDCeCapIncrease_20231221';
+  }
+  
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3PolygonAssets.USDC_UNDERLYING,
+      48_000_000,
+      43_500_000
+    );
+
+    return capUpdates;
+  }
+}


### PR DESCRIPTION
There is an issue with 2 conflicting proposals which can be resolved with the risk steward to increase caps - USDC.e caps were lowered on v3 Polygon on proposal 409 (migration to Native USDC) while proposal 414 tries to migrate USDC from the treasury from v2 Polygon to USDC.e on v3 Polygon.
We can solve this by raising the USDC.e supply cap on V3 Polygon to enable the execution of the proposal.

This PR implements:
1. Cap increase for USDCe on Polygon V3:
      Supply Cap 40M -> 48M
      Borrow Cap 36M -> 43.5M
2. AIP-414 (PayloadId 22) Execution bytecode creation.