### PR TITLE
Polygon MaticX Supply Cap Increase 20240311

### DIFF
--- a/diffs/pre_PolygonMaticXSupplyCapIncrease_20240311_post_PolygonMaticXSupplyCapIncrease_20240311.md
+++ b/diffs/pre_PolygonMaticXSupplyCapIncrease_20240311_post_PolygonMaticXSupplyCapIncrease_20240311.md
@@ -1,0 +1,25 @@
+## Reserve changes
+
+### Reserves altered
+
+#### MaticX ([0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6](https://polygonscan.com/address/0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6))
+
+| description | value before | value after |
+| --- | --- | --- |
+| supplyCap | 75,000,000 MaticX | 82,500,000 MaticX |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6": {
+      "supplyCap": {
+        "from": 75000000,
+        "to": 82500000
+      }
+    }
+  }
+}
+```

--- a/src/PolygonMaticXSupplyCapIncrease_20240311.s.sol
+++ b/src/PolygonMaticXSupplyCapIncrease_20240311.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {CapsPlusRiskStewardPolygon} from '../scripts/CapsPlusRiskStewardPolygon.s.sol';
+
+/**
+ * @title Increase MaticX Supply Cap on Polygon V3
+ * @author @ChaosLabsInc
+ * - Discussion: https://governance.aave.com/t/chaos-labs-risk-stewards-increase-maticx-supply-cap-on-v3-polygon-03-11-24/16920
+ */
+contract PolygonMaticXSupplyCapIncrease_20240311 is CapsPlusRiskStewardPolygon {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'PolygonMaticXSupplyCapIncrease_20240311';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3PolygonAssets.MaticX_UNDERLYING,
+      82_500_000,
+      EngineFlags.KEEP_CURRENT
+    );
+
+    return capUpdates;
+  }
+}


### PR DESCRIPTION
Discussion: https://governance.aave.com/t/chaos-labs-risk-stewards-increase-maticx-supply-cap-on-v3-polygon-03-11-24/16920